### PR TITLE
fix to show collection data type parsing

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>swagger-core_2.11</artifactId>
   <packaging>bundle</packaging>
   <name>swagger-core</name>
-  <version>1.3.13</version>
+  <version>1.3.13-ciena-bp-0.0.1</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <defaultGoal>install</defaultGoal>

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -214,7 +214,8 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
       if (!"void".equals(paramType) && null != paramType && !processedFields.contains(name)) {
         if(!excludedFieldTypes.contains(paramType)) {
           val items = {
-            val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-0-9_]*)\\].*".r
+            // will match PceTpe , Array[PceTpe] , Array[com.ciena.bpnetworkcorelib.interfaces.PceTpeFreModelV1$PceTpe] etc
+            val ComplexTypeMatcher = "([a-zA-Z]*)\\[([\\w]+[\\.\\w]*[\\.\\w\\$\\w]*)\\].*".r
             val nameToUse = {
               if(overrideDataType != null) 
                 overrideDataType


### PR DESCRIPTION
swagger ui not able to show Array[class] as swagger core not able to parse information for inners classes like a.b.c$d . entity type like Array[a.b.c$d] not visible in expanded form on the UI . 

regular expression  has been fixed to return the correct class type 
